### PR TITLE
Add an arrow up button on the Home page

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import jsQuizLogo from '../../assets/images/logo.svg';
 import s from './Home.module.css';
@@ -8,10 +8,58 @@ import { NOTES, QUIZZES } from '../../App';
 import { Link } from 'react-router-dom';
 import ContactForm from './ContactForm';
 import HighlightsSection from './Highlights';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 export default function Home({ highlights, snackbar }) {
+  const [scrollToTopVisible, setScrollToTopVisible] = useState(false);
+  const handleScroll = () => {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    setScrollToTopVisible(scrollTop > 200);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
   return (
     <>
+      {/* Add a "Scroll to Top" button */}
+      {scrollToTopVisible && (
+        <Button
+          onClick={scrollToTop}
+          variant="contained"
+          sx={{
+            position: 'fixed',
+            bottom: '20px',
+            right: '20px',
+            zIndex: '1000',
+            backgroundColor: customColors.backgroundLight,
+            '&:hover': {
+              backgroundColor: 'primary',
+              '& svg': {
+                color: customColors.white, // Change to your preferred hover color for the icon
+              },
+            },
+          }}
+        >
+          <KeyboardArrowUpIcon
+            sx={{
+              fontSize: 32,
+              color: customColors.greyMedium,
+            }}
+          />
+        </Button>
+      )}
       {/*Home section*/}
       <Box className={s.homeBackground}>
         <img alt="JSQuiz logo" className={s.logoImage} src={jsQuizLogo} />


### PR DESCRIPTION
## Summary:

Add an arrow up button on the Home page.

## Requirements:
- When scrolling, an upward arrow button should appear. Clicking on it should navigate the page back to the top.

## UX/UI Outcome:
<details open>
  <summary><b>Button</b></summary>
<img width="108" alt="Screenshot 2023-12-12 at 3 57 12 PM" src="https://github.com/Code-the-Dream-School/ee-prac-team3-front/assets/111474106/b1b194a5-97d7-49a2-b4ac-c956d14d1944">

<i>On hovering over</i>
<img width="107" alt="Screenshot 2023-12-12 at 3 59 45 PM" src="https://github.com/Code-the-Dream-School/ee-prac-team3-front/assets/111474106/a1a20ef8-e186-4ef0-9c3f-e76ce4d3a4de">
</details>